### PR TITLE
ns/resource: add flush operation

### DIFF
--- a/ns/resource.md
+++ b/ns/resource.md
@@ -63,3 +63,17 @@ Returns the actual bytes written on success, or the error on failure.
 Closes the resource specified by `id`.
 
 Calling this on an invalid resource id is a fatal error.
+
+### flush
+
+**Parameters:**
+
+- `id`: `i32`
+
+**Returns:** `i32`
+
+**Semantics:**
+
+Instructs the resource specified by `id` to flush the output stream, ensuring that all intermediately buffered contents reach their destination.
+
+Returns `0` on success, or the error on failure.


### PR DESCRIPTION
This allows CommonWA programs to instruct a resource to flush all pending bytes to their desired target. This will allow for the implementation of the HTTP/HTTPS transport scheme among other future fun goodies.