### PR TITLE
Improve project's heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Common WebAssembly API
 
-The Common WebAssembly API is a minimal specification of the standard API for non-Web WebAssembly usermode environments.
+## The project
+
+Common WebAssembly API (CWA) is a minimal specification of a standard API to implement [non-Web WebAssembly](https://webassembly.org/docs/non-web/) in virtualized environments.
+
+## Objectives
+
+<sup>TODO: add how the project's objectives are inspired by WA official doc about "non-Web" WebAssembly ecosystem (with quotations)</sup>
 
 ## Structure
 


### PR DESCRIPTION
As a general approach is better to give some trail of the research that took to the idea. Without some references to existing work at hand, it is pretty difficult to navigate the subject.

An extract from WA doc:
> Non-Web environments may provide different APIs than Web environments, which feature testing and dynamic linking will make discoverable and usable.

Are these lines relevant for the scope of cwa? I added an "objectives" paragraph to collect these useful cross-references.

In practice, I provided a better rooted heading for the happiness of everybody!

cc @Xe 